### PR TITLE
Add primeSequence onscreen controls

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -116,7 +116,16 @@
         <input type="range" min="1" max="2" value="2" class="slider" id="key-mode-switch-slider">
         <label id="key-mode-switch-label" for="key-mode-switch-check">Random</label>
         <input type="checkbox" id="keyModeSwitch-check" name="key-mode-switch-check" checked="checked">
-        <button id="section-shift-persist-toggle" onclick="sectionModeShift()">Persist</button>
+        <button id="section-shift-persist-toggle" onclick="sectionModeShiftPersist()">Persist</button>
+      </div>
+
+      <div class="slidecontainer">
+        <p class="slider-title">Prime section harmonic sequence?</p>
+        <p class="slider-value"><span id="prime-sequence-output">...</span></p>
+        <input type="range" min="1" max="8" value="8" class="slider" id="prime-sequence-slider">
+        <label id="prime-sequence-label" for="prime-sequence-check">Random</label>
+        <input type="checkbox" id="primeSequence-check" name="prime-sequence-check">
+        <button id="prime-sequence-persist-toggle" onclick="primeSectionSequencePersist()">Persist</button>
       </div>
 
     </div>

--- a/js/music-generator/control.js
+++ b/js/music-generator/control.js
@@ -8,7 +8,8 @@ let onScreenFirstPassOptions = {
     keyMode: undefined,
     numOfChords: undefined,
     numOfRepeats: undefined,
-    keyModeSwitch: undefined
+    keyModeSwitch: undefined,
+    primeSequence: undefined
     // persistState: undefined
 }
 
@@ -50,6 +51,11 @@ function masterControl() {
     if (controlOptions.keyModeSwitch !== undefined) {
         keyModeSwitchConBool = true;
         keyModeSwitchOption = controlOptions.keyModeSwitch;
+    }
+
+    if (controlOptions.primeSequence !== undefined) {
+        primeSequenceConBool = true;
+        primeSequenceOption = controlOptions.primeSequence;
     }
 
     // if (controlOptions.persistState !== undefined) {
@@ -101,7 +107,7 @@ function startingChordOptionHandler() {
     startingChordOutput.innerHTML = currentHarmony[startingChordSlider.value - 1];
 
     startingChordSlider.onclick = () => multiDataControlDisplay();
-    
+
     startingChordSlider.onmousedown = () => {
         startingChordCheckbox.checked = false;
         displayHandler();
@@ -149,7 +155,7 @@ function cadenceControlHandler() {
     cadenceSliderOutput.innerHTML = '...';
 
     cadenceSlider.onclick = () => multiDataControlDisplay();
-    
+
     cadenceSlider.onmousedown = () => {
         cadenceCheckbox.checked = false;
         displayHandler();
@@ -199,7 +205,7 @@ function keyCenterControlHandler() {
     keyCenterSliderOutput.innerHTML = '...';
 
     keyCenterSlider.onclick = () => multiDataControlDisplay();
-    
+
     keyCenterSlider.onmousedown = () => {
         keyCenterCheckbox.checked = false;
         displayHandler();
@@ -255,7 +261,7 @@ function keyModeControlHandler() {
         startChordDisplay.innerHTML = currentHarmony[startChordSlider.value - 1];
         multiDataControlDisplay();
     }
-    
+
     keyModeSlider.onmousedown = () => {
         // turn off checkboxx
         keyModeCheckbox.checked = false;
@@ -283,7 +289,7 @@ function numChordsHandler() {
             numChordsSliderOutput.innerHTML = '...';
             numChordsSlider.style.opacity = 0.3;
             numChordsLabel.style.opacity = 1;
-        } else  if (chordsCheckbox.checked === false) {
+        } else if (chordsCheckbox.checked === false) {
             numChordsSliderOutput.innerHTML = numChordsSlider.value;
             numChordsSlider.style.opacity = 0.9;
             numChordsLabel.style.opacity = 0.4;
@@ -308,7 +314,7 @@ function numChordsHandler() {
     numChordsSliderOutput.innerHTML = '...';
 
     numChordsSlider.onclick = () => multiDataControlDisplay();
-    
+
     numChordsSlider.onmousedown = () => {
         chordsCheckbox.checked = false;
         displayHandler();
@@ -415,8 +421,59 @@ function keyModeSwitchHandler() {
 
     keyModeSwitchCheckbox.oninput = () => multiDataControlDisplay();
 }
-
 keyModeSwitchHandler();
+
+function primeSequenceHandler() {
+    let primeSequenceArray = ['No change', 'Up a second', 'Up a third', 'Up a fourth', 'Up a fifth', 'Up a sixth', 'Up a seventh', 'Strongest Most Often'];
+    let primeSequenceSlider = document.getElementById("prime-sequence-slider");
+    let primeSequenceSliderOutput = document.getElementById("prime-sequence-output");
+    let primeSequenceCheckbox = document.getElementById("primeSequence-check");
+    let primeSequenceLabel = document.getElementById('prime-sequence-label');
+
+    function displayHandler() {
+        // display handling
+        if (primeSequenceCheckbox.checked === true) {
+            primeSequenceSliderOutput.innerHTML = '...';
+            primeSequenceSlider.style.opacity = 0.3;
+            primeSequenceLabel.style.opacity = 1;
+        } else if (primeSequenceCheckbox.checked === false) {
+            primeSequenceSliderOutput.innerHTML = primeSequenceArray[primeSequenceSlider.value - 1];
+            primeSequenceSlider.style.opacity = 0.9;
+            primeSequenceLabel.style.opacity = 0.4;
+        }
+    }
+
+    function controlHandler() {
+        // indicate user control
+        primeSequenceConBool = true;
+        // set random boolean from checkbox
+        primeSequenceRandom = primeSequenceCheckbox.checked;
+    }
+
+    function multiDataControlDisplay() {
+        // push value that was hidden to control object
+        onScreenFirstPassOptions.primeSequence = primeSequenceSlider.value;
+        controlHandler();
+        displayHandler();
+    }
+
+    // handle on-page-load conditional styling
+    primeSequenceCheckbox.checked === false && displayHandler();
+
+    primeSequenceSlider.onclick = () => multiDataControlDisplay();
+
+    primeSequenceSlider.onmousedown = () => {
+        primeSequenceCheckbox.checked = false;
+        displayHandler();
+    }
+
+    primeSequenceSlider.oninput = () => displayHandler();
+
+    primeSequenceCheckbox.oninput = () => multiDataControlDisplay();
+}
+primeSequenceHandler();
+
+
 
 // Persist buttons
 function startChordPersist() {
@@ -457,11 +514,18 @@ function numChordPersist() {
     numOfChordsPersist === true ? element.style.backgroundColor = 'pink' : element.style.backgroundColor = 'white';
 }
 
-function sectionModeShift() {
+function sectionModeShiftPersist() {
     let element = document.getElementById('section-shift-persist-toggle');
     keyModeSwitchConBool = true;
     keyModeSwitchPersist = !keyModeSwitchPersist;
     keyModeSwitchPersist === true ? element.style.backgroundColor = 'pink' : element.style.backgroundColor = 'white';
+}
+
+function primeSectionSequencePersist() {
+    let element = document.getElementById('prime-sequence-persist-toggle');
+    primeSequenceConBool = true;
+    primeSequencePersist = !primeSequencePersist;
+    primeSequencePersist === true ? element.style.backgroundColor = 'pink' : element.style.backgroundColor = 'white';
 }
 
 // turn off control booleans
@@ -489,6 +553,10 @@ function turnControlOff() {
 
     if (keyModeSwitchPersist === false) {
         keyModeSwitchConBool = false;
+    }
+
+    if (primeSequencePersist === false) {
+        primeSequenceConBool = false;
     }
 
     numOfRepeatsConBool = false;

--- a/js/music-generator/harmony.js
+++ b/js/music-generator/harmony.js
@@ -260,6 +260,11 @@ let typeOfCadenceConBool = false;
 let typeOfCadenceOption;
 let typeOfCadenceRandom = true;
 
+let primeSequencePersist = false;
+let primeSequenceConBool = false;
+let primeSequenceOption;
+let primeSequenceRandom = false;
+
 // makes a base unit of chords
 function createHarmonicUnit(section, formNum, phraseChart) {
     let {
@@ -334,7 +339,7 @@ function createHarmonicUnit(section, formNum, phraseChart) {
     } else if (startingChordConBool === true && startingChordRandom === true) { // random checkbox enabled
         startingChordConVar = generateChance(7);
     } else { // hard-coded option
-        generateChance(2) === 1 ? startingChordConVar = 1 : startingChordConVar = generateChance(7);
+        phraseContainer.length === 0 ? startingChordConVar = 1 : generateChance(2) === 1 ? startingChordConVar = 1 : startingChordConVar = generateChance(7);
     }
 
     // onscreen user controled option has been clicked, random box onchecked
@@ -344,6 +349,37 @@ function createHarmonicUnit(section, formNum, phraseChart) {
         typeOfCadenceConVar = generateChance(4);
     } else { // hard-coded option
         typeOfCadenceConVar = generateChance(3, 1);
+    }
+
+    function harmonicSequenceHandler() {
+
+        // onscreen harmonic sequencing option
+        if (primeSequenceConBool === true && primeSequenceRandom === false) {
+            primeSequenceConVar = primeSequenceOption;
+            primeSequenceConVar = Number(primeSequenceConVar);
+            if (primeSequenceConVar === 1) {
+                // do nothing
+            } else if (primeSequenceConVar > 1 && primeSequenceConVar < 8) {
+                harmonicDiatonicSequencer(primeSequenceConVar);
+            } else if (primeSequenceConVar >= 8) {
+                strongestMostOften();
+            }
+        } else if (primeSequenceConBool === true && primeSequenceRandom === true) { // random checkbox enabled
+            primeSequenceConVar = generateChance(8);
+            harmonicDiatonicSequencer(primeSequenceConVar);
+        } else { // hard-coded option
+            strongestMostOften();
+        }
+
+        function strongestMostOften() {
+            // sequence by stongest motion most often
+            let sequenceChance = generateChance(20);
+            if (sequenceChance <= 8) {
+                harmonicDiatonicSequencer(generateChance(8));
+            } else if (sequenceChance > 8) {
+                harmonicDiatonicSequencer(4);
+            }
+        }
     }
 
     // CONTROL HANDLING --------------
@@ -359,13 +395,7 @@ function createHarmonicUnit(section, formNum, phraseChart) {
     } else if (section === 1) {
         info.formId = formNum + ':A1';
         info.tempo = phraseContainer[(formNum - 1) * 4][0].tempo;
-        // sequence by stongest motion most often
-        let sequenceChance = generateChance(20);
-        if (sequenceChance <= 8) {
-            harmonicDiatonicSequencer(generateChance(8));
-        } else if (sequenceChance > 8) {
-            harmonicDiatonicSequencer(4);
-        }
+        harmonicSequenceHandler();
         cadenceHandler(section);
         storePlaybackData();
         // third 4 bar phrase


### PR DESCRIPTION
This commit adds an onscreen control with full persist and random
options.

Sometimes, if the phrase only has 3 chords, the desired sequence can not
be obtained while keeping strong motion. Either onscreen message needs
to be applied or a special case handler built.