### PR TITLE
Add rangeHandler and diagnostics

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -142,6 +142,8 @@
       <p>Helper</p>
       <button onclick="console.log(phraseContainer)">phraseContainer</button>
       <button onclick="checkForUndefined()">Check undefined</button>
+      <button onclick="checkForRange()">Check range</button>
+
       <button onclick="resetPlay()">Reset and Play</button>
     </div>
 

--- a/js/music-generator/control.js
+++ b/js/music-generator/control.js
@@ -486,7 +486,6 @@ function startChordPersist() {
     startingChordPersist === true ? element.style.backgroundColor = 'pink' : element.style.backgroundColor = 'white';
     // assign data for control variable
     startingChordOption = document.querySelector('#starting-chord-slider').value;
-    console.log(document.querySelector('#starting-chord-slider').value);
 }
 
 function cadencePersist() {

--- a/js/music-generator/elements.js
+++ b/js/music-generator/elements.js
@@ -32,6 +32,24 @@ function checkForUndefined() {
     }
 }
 
+function checkForRange() {
+    for (i = 0; i <= phraseContainer.length - 1; i++) {
+        console.log('range:  ' + i);
+        phraseContainer[i][0].voiceLeading[0].forEach( (note) => {
+            rangeHandler('bass', note) && console.log('Bass out of range' + note);
+        });
+        phraseContainer[i][0].voiceLeading[1].forEach( (note) => {
+            rangeHandler('tenor', note) && console.log('Tenor out of range' + note);
+        });
+        phraseContainer[i][0].voiceLeading[2].forEach( (note) => {
+            rangeHandler('alto', note) && console.log('Alto out of range' + note);
+        });
+        phraseContainer[i][0].voiceLeading[3].forEach( (note) => {
+            rangeHandler('soprano', note) && console.log('Soprano out of range' + note);
+        });
+    }
+}
+
 function makePersist() {
     if (onScreenFirstPassOptions.persistState !== undefined) {
         onScreenFirstPassOptions.persistState = !onScreenFirstPassOptions.persistState;

--- a/js/music-generator/harmony.js
+++ b/js/music-generator/harmony.js
@@ -427,7 +427,7 @@ let numOfChordsOption;
 let numOfChordsRandom = true;
 let progression = [];
 
-function getNewProgression(start, cadence, section, info) {
+function getNewProgression(start, cadence, section) {
     // onscreen user controled option has been clicked, random box unchecked
     if (numOfChordsConBool === true && numOfChordsRandom === false) {
         numOfChordsConVar = numOfChordsOption;
@@ -442,7 +442,7 @@ function getNewProgression(start, cadence, section, info) {
 
     function generateInitialHarmonies() {
         for (let i = 1; i <= numOfChordsConVar - 1; i++) {
-            progression[i] = generateStrongMotion(progression[i - 1], info);
+            progression[i] = generateStrongMotion(progression[i - 1]);
         }
         // THIS is where I can add raised harmonies
         if (currentHarmony === minor) {
@@ -493,13 +493,13 @@ function getNewProgression(start, cadence, section, info) {
         if (cadence === 'Plagal') {
             for (let i = 1; i <= progression.length - 2; i++) {
                 if (checkIfStrong(progression[i - 1], progression[i]) === false) {
-                    return getNewProgression(start, cadence, section, info);
+                    return getNewProgression(start, cadence, section);
                 }
             }
         } else {
             for (let i = 1; i <= progression.length - 1; i++) {
                 if (checkIfStrong(progression[i - 1], progression[i]) === false) {
-                    return getNewProgression(start, cadence, section, info);
+                    return getNewProgression(start, cadence, section);
                 }
             }
         }
@@ -509,7 +509,7 @@ function getNewProgression(start, cadence, section, info) {
     progression[0] = start;
     generateInitialHarmonies();
     assignNewCadence();
-    checkForStrongMotion(info);
+    checkForStrongMotion();
     return progression;
 }
 
@@ -525,7 +525,7 @@ function harmonicDiatonicSequencer(degreesUp) {
     }
 }
 
-function generateStrongMotion(chord, info) {
+function generateStrongMotion(chord) {
     switch (generateChance(7)) {
         case 1:
             return motionUpSecond(chord);

--- a/js/music-generator/webaudiogen.js
+++ b/js/music-generator/webaudiogen.js
@@ -69,14 +69,13 @@ let sopranoGain = audioContext.createGain();
 
 function satbNodeConnector() {
     for (let i = 0; i <= pianoExtendedC.length - 1; i++) {
-        if (i > 32) { // F3 and below
+        if (i >= 33) { // F3 and below
             pianoTrackArray[i].connect(bassGain);
             bassGain.connect(audioContext.destination);
-        } else if (i <= 32 && i > 23) { // Gb3 to D4
+        } else if (i <= 32 && i >= 24) { // Gb3 to D4
             pianoTrackArray[i].connect(tenorGain);
             tenorGain.connect(audioContext.destination);
-
-        } else if (i <= 23 && i > 14) { // Eb4 to B4
+        } else if (i <= 23 && i >= 15) { // Eb4 to B4
             pianoTrackArray[i].connect(altoGain);
             altoGain.connect(audioContext.destination);
         } else if (i <= 14) { // C5 and above


### PR DESCRIPTION
A range handler has been added in voice-leading.js. Min/max values can
be set, and object used for further dev on voice range control.

Partially fixes gain node issue, as previously seperate voices were
occasionally resolving to the same chord, and therefore only playing
once, and breaking during arpeggiation. Further testing required on this
issue.

Adds diagnostic functions for rangeHandling to onscreen controls.